### PR TITLE
add support for prism structured logging

### DIFF
--- a/acceptance/tests/structured_log.go
+++ b/acceptance/tests/structured_log.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "code.cloudfoundry.org/cf-drain-cli/acceptance/helpers"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	"time"
+	"code.cloudfoundry.org/cf-drain-cli/acceptance"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("StructuredLog", func() {
+	var appName string
+	BeforeEach(func() {
+		appName = PushLogWriter()
+	})
+
+	AfterEach(func() {
+		deleteApp := func(appName string) {
+			CF("delete", appName, "-f", "-r")
+		}
+
+		deleteApp(appName)
+	})
+
+	It("creates a structured log drain and deletes it", func() {
+		CF(
+			"enable-structured-logging",
+			appName,
+			"dogstatsd",
+			"--drain-name", "drain-name",
+		)
+
+		Eventually(func() string {
+			s := cf.Cf("drains")
+			Eventually(s, acceptance.Config().DefaultTimeout).Should(gexec.Exit(0))
+			return string(append(s.Out.Contents(), s.Err.Contents()...))
+		}, acceptance.Config().DefaultTimeout+3*time.Minute).Should(And(
+			ContainSubstring("drain-name"),
+			ContainSubstring("prism://dogstatsd"),
+		))
+	})
+
+})

--- a/internal/command/enable_structured_logging.go
+++ b/internal/command/enable_structured_logging.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"code.cloudfoundry.org/cli/plugin"
+	"github.com/jessevdk/go-flags"
+)
+
+type enableStructuredLoggingArgs struct {
+	AppName               string
+	DrainName             string `long:"drain-name"`
+	StructuredLoggingType string
+}
+
+func EnableStructuredLogging(
+	cli plugin.CliConnection,
+	args []string,
+	d Downloader,
+	log Logger,
+) {
+	opts := enableStructuredLoggingArgs{}
+
+	parser := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash)
+	args, err := parser.ParseArgs(args)
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	if len(args) != 2 {
+		log.Fatalf("Invalid arguments, expected 2, got %d.", len(args))
+	}
+
+	opts.AppName = args[0]
+	opts.StructuredLoggingType = args[1]
+
+	CreateDrain(
+		cli,
+		[]string{
+			opts.AppName,
+			"prism://" + opts.StructuredLoggingType,
+			"--drain-name",
+			opts.DrainName,
+		},
+		d,
+		log,
+	)
+}

--- a/internal/command/enable_structured_logging_test.go
+++ b/internal/command/enable_structured_logging_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = FDescribe("EnableStructuredLogging", func() {
+var _ = Describe("EnableStructuredLogging", func() {
 	var (
 		logger *stubLogger
 		cli    *stubCliConnection

--- a/internal/command/enable_structured_logging_test.go
+++ b/internal/command/enable_structured_logging_test.go
@@ -1,0 +1,78 @@
+package command_test
+
+import (
+	"code.cloudfoundry.org/cf-drain-cli/internal/command"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = FDescribe("EnableStructuredLogging", func() {
+	var (
+		logger *stubLogger
+		cli    *stubCliConnection
+	)
+
+	BeforeEach(func() {
+		logger = &stubLogger{}
+		cli = newStubCliConnection()
+	})
+
+	It("creates and binds to a user provided service", func() {
+		args := []string{"app-name", "DogStatsD"}
+
+		command.EnableStructuredLogging(cli, args, nil, logger)
+
+		Expect(cli.cliCommandArgs).To(HaveLen(2))
+		Expect(cli.cliCommandArgs[0]).To(ConsistOf(
+			"create-user-provided-service",
+			MatchRegexp("cf-drain-.*"),
+			"-l",
+			"prism://DogStatsD",
+		))
+
+		Expect(cli.cliCommandArgs[1]).To(ConsistOf(
+			"bind-service",
+			"app-name",
+			MatchRegexp("cf-drain-.*"),
+		))
+	})
+
+	Describe("drain name flag", func() {
+		It("creates and binds to a user provided service with the given name", func() {
+			args := []string{
+				"app-name",
+				"DogStatsD",
+				"--drain-name", "my-drain",
+			}
+
+			command.EnableStructuredLogging(cli, args, nil, logger)
+
+			Expect(cli.cliCommandArgs).To(HaveLen(2))
+			Expect(cli.cliCommandArgs[0]).To(ConsistOf(
+				"create-user-provided-service",
+				"my-drain",
+				"-l", "prism://DogStatsD",
+			))
+
+			Expect(cli.cliCommandArgs[1]).To(ConsistOf(
+				"bind-service",
+				"app-name",
+				"my-drain",
+			))
+		})
+	})
+
+	It("fatally logs if the incorrect number of arguments are given", func() {
+		Expect(func() {
+			command.EnableStructuredLogging(nil, []string{}, nil, logger)
+		}).To(Panic())
+
+		Expect(logger.fatalfMessage).To(Equal("Invalid arguments, expected 2, got 0."))
+
+		Expect(func() {
+			command.EnableStructuredLogging(nil, []string{"one", "two", "three", "four"}, nil, logger)
+		}).To(Panic())
+
+		Expect(logger.fatalfMessage).To(Equal("Invalid arguments, expected 2, got 4."))
+	})
+})

--- a/main.go
+++ b/main.go
@@ -63,6 +63,11 @@ func (c CFDrainCLI) Run(conn plugin.CliConnection, args []string) {
 			c.exitWithUsage("delete-drain-space")
 		}
 		command.DeleteSpaceDrain(conn, args[1:], logger, os.Stdin, sdClient, command.DeleteDrain)
+	case "enable-structured-logging":
+		if len(args) < 3 {
+			c.exitWithUsage("enable-structured-logging")
+		}
+		command.EnableStructuredLogging(conn, args[1:], downloader, logger)
 	}
 }
 
@@ -136,6 +141,16 @@ func (c CFDrainCLI) GetMetadata() plugin.PluginMetadata {
 					Usage: "delete-drain-space DRAIN_NAME [--force]",
 					Options: map[string]string{
 						"-force": "Skip warning prompt. Default is false",
+					},
+				},
+			},
+			{
+				Name:     "enable-structured-logging",
+				HelpText: "Creates a user provided service for Prism structured logging and binds it to a given application.",
+				UsageDetails: plugin.Usage{
+					Usage: "enable-structured-logging APP_NAME STRUCTURED_LOGGING_TYPE [--drain-name NAME]",
+					Options: map[string]string{
+						"-drain-name": "The name of the drain that will be created. If excluded, the drain name will be `cf-drain-UUID`.",
 					},
 				},
 			},


### PR DESCRIPTION
This adds an `enable-structured-logging` command, which creates a syslog drain with a `prism://` URL.

[#157937025]